### PR TITLE
Added a cause of death definition

### DIFF
--- a/datasets/ONS-Deaths-involving-COVID-19-in-the-care-sector-England-and-Wales-deaths-occurring-up-to-1-May-2020-and-registered-up-to-9-May-2020-provisional/info.json
+++ b/datasets/ONS-Deaths-involving-COVID-19-in-the-care-sector-England-and-Wales-deaths-occurring-up-to-1-May-2020-and-registered-up-to-9-May-2020-provisional/info.json
@@ -35,6 +35,10 @@
                 "unit": "http://gss-data.org.uk/def/concept/measurement-units/deaths",
                 "measure": "http://gss-data.org.uk/def/measure/cumulative-count",
                 "datatype": "integer"
+            },
+            "Cause of Death": {
+                "description": "The cause of death reported represents the final underlying cause of death.",
+                "source": "https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/methodologies/mortalitystatisticsinenglandandwalesqmi"
             }
         },
         "codelists": [


### PR DESCRIPTION
Added a definition for 'cause of death' to https://staging.gss-data.org.uk/resource?uri=http%3A%2F%2Fgss-data.org.uk%2Fdata%2Fgss_data%2Fcovid-19%2Fons-deaths-involving-covid-19-in-the-care-sector-england-and-wales-deaths-occurring-up-to-1-may-2020-and-registered-up-to-9-may-2020-provisional%23dimension%2Fcause-of-death

Which relates to the dataset: ons-deaths-involving-covid-19-in-the-care-sector-england-and-wales-deaths-occurring-up-to-1-may-2020-and-registered-up-to-9-may-2020-provisional

This is my first commit so please be kind to me!