### PR TITLE
adding-dimensions-change-dimension-to-parent

### DIFF
--- a/datasets/ONS-Deaths-involving-COVID-19-in-the-care-sector-England-and-Wales-deaths-occurring-up-to-1-May-2020-and-registered-up-to-9-May-2020-provisional/info.json
+++ b/datasets/ONS-Deaths-involving-COVID-19-in-the-care-sector-England-and-Wales-deaths-occurring-up-to-1-May-2020-and-registered-up-to-9-May-2020-provisional/info.json
@@ -20,15 +20,15 @@
         ],
         "columns": {
             "Period": {
-                "dimension": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refPeriod",
                 "value": "http://reference.data.gov.uk/id/{+period}"
             },
             "Local Authority": {
-                "dimension": "http://purl.org/linked-data/sdmx/2009/dimension#refArea",
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#refArea",
                 "value": "http://statistics.data.gov.uk/id/statistical-geography/{local_authority}"
             },
             "Sex": {
-                "dimension": "http://purl.org/linked-data/sdmx/2009/dimension#sex",
+                "parent": "http://purl.org/linked-data/sdmx/2009/dimension#sex",
                 "value": "http://purl.org/linked-data/sdmx/2009/code#sex-{sex}"
             },
             "Value": {

--- a/datasets/ONS-Online-price-changes-for-high-demand-products/info.json
+++ b/datasets/ONS-Online-price-changes-for-high-demand-products/info.json
@@ -34,6 +34,9 @@
                 "unit": "http://gss-data.org.uk/def/concept/measurement-units/price-indice-change",
                 "measure": "http://gss-data.org.uk/def/measure/percent",
                 "datatype": "float64"
+            },
+            "Product": {
+                "description":"These products were chosen at the beginning of lockdown using anecdotal evidence on which products were in high demand from consumers.",          		"source":"https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/methodologies/onlineweeklypricechangesmethodology"
             }
         },
         "codelists": [


### PR DESCRIPTION
Changed 'dimension' to 'parent' in ONS-Deaths-involving-COVID-19-in-the-care-sector-England-and-Wales-deaths-occurring-up-to-1-May-2020-and-registered-up-to-9-May-2020-provisional

Added a dimension description for 'product' for the ons-online-price-changes-for-high-demand-products dataset